### PR TITLE
Fix #2: Add a --json option to render valid JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fony
 
-fony is a **simple** command line tool that generates dummy JSON data from 
+fony is a **simple** command line tool that generates dummy JSON data from
 a provided template.
 
 The application utilizes [Chance.js](http://chancejs.com/) under the hood
@@ -27,6 +27,8 @@ npm install --global fony
     -V, --version              output the version number
     -t, --template <template>  JSON template for data to be generated
     -c, --count [count]        The number of elements to create, defaults to 1
+    -j, --json                 Format the output as valid JSON, defaults to false
+
 ```
 
 ![fony](https://cloud.githubusercontent.com/assets/1857993/24695518/c4ab67e8-19ab-11e7-98e3-330fa48a14d3.gif)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ npm install --global fony
     -V, --version              output the version number
     -t, --template <template>  JSON template for data to be generated
     -c, --count [count]        The number of elements to create, defaults to 1
-    -j, --json                 Format the output as valid JSON, defaults to false
 
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ program
 program
   .option('-t, --template <template>', 'JSON template for data to be generated')
   .option('-c, --count [count]', 'The number of elements to create, defaults to 1', 1)
+  .option('-j, --json', 'Format the output as valid JSON, defaults to false', true)
   .parse(process.argv);
 
 var template;
@@ -21,12 +22,16 @@ try {
   return console.log(error);
 }
 
+function format(source, asJSON) {
+  return asJSON ? JSON.stringify(source, null, 2) : source;
+}
+
 if (program.count > 1) {
   var output = [];
   for (var i = 0; i < program.count; i++) {
     output.push(createData(template));
   }
-  return console.log(output);
+  return console.log(format(output, program.json));
 } else {
-  return console.log(createData(template));
+  return console.log(format(createData(template), program.json));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ program
 program
   .option('-t, --template <template>', 'JSON template for data to be generated')
   .option('-c, --count [count]', 'The number of elements to create, defaults to 1', 1)
-  .option('-j, --json', 'Format the output as valid JSON, defaults to false', true)
   .parse(process.argv);
 
 var template;
@@ -22,8 +21,8 @@ try {
   return console.log(error);
 }
 
-function format(source, asJSON) {
-  return asJSON ? JSON.stringify(source, null, 2) : source;
+function format(source) {
+  return JSON.stringify(source, null, 2);
 }
 
 if (program.count > 1) {
@@ -31,7 +30,7 @@ if (program.count > 1) {
   for (var i = 0; i < program.count; i++) {
     output.push(createData(template));
   }
-  return console.log(format(output, program.json));
+  return console.log(format(output));
 } else {
-  return console.log(format(createData(template), program.json));
+  return console.log(format(createData(template)));
 }


### PR DESCRIPTION
This adds a `-j, --json` option to the command line to have the output formatted as valid JSON (refs #2).

```
➜  fony git:(valid-json-output) node src/index.js --help

  Usage: index [options]

  Options:

    -h, --help                 output usage information
    -V, --version              output the version number
    -t, --template <template>  JSON template for data to be generated
    -c, --count [count]        The number of elements to create, defaults to 1
    -j, --json                 Format the output as valid JSON, defaults to false

➜  fony git:(valid-json-output) ✗ node src/index.js -t '{"data": {"name": "name"}}' 
{ data: { name: 'Rosa Silva' } }
➜  fony git:(valid-json-output) ✗ node src/index.js -t '{"data": {"name": "name"}}'  -j
{
  "data": {
    "name": "Willie Griffin"
  }
}
```