### PR TITLE
Add support for fixture arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,30 @@ But Windows handles quotes on the command line differently, so be sure to escape
 fony -t "{\"name\": \"name\", \"age\": \"age\", \"address\": \"address\"}" -c 2
 ```
 
+## Niceties
+
+fony supports nested fixtures:
+
+```js
+$ fony -t '{"foo": {"bar": "name"}}'
+{
+  "foo": {
+    "bar": "Virgie Davidson"
+  }
+}
+```
+
+As well as arrays:
+
+```js
+$ fony -t '{"tags": ["word", 3]}'
+{
+  "tags": [
+    "oklu",
+    "odikabi",
+    "coan"
+  ]
+}
+```
+
 ![fony](https://cloud.githubusercontent.com/assets/1857993/24695518/c4ab67e8-19ab-11e7-98e3-330fa48a14d3.gif)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,24 +1,31 @@
 const Chance = require("chance");
 
 const chance = new Chance();
+const chanceTypes = Object.keys(Object.getPrototypeOf(chance));
+
+function valid(type) {
+  return chanceTypes.indexOf(type) !== -1;
+}
 
 function getArrayValue(definition) {
-  var type = definition[0];
-  var count = definition[1];
-  if (typeof type === "string" && typeof count === "number" && count > 0) {
-    return new Array(count).fill(null).map(function() {
-      return getValue(type);
-    });
-  } else {
-    return [];
+  if (definition.length !== 2) {
+    return null;
   }
+  const type = definition[0];
+  const count = definition[1];
+  if (!valid(type) || typeof count !== "number" || count === 0) {
+    return null;
+  }
+  return new Array(count).fill(null).map(function() {
+    return getValue(type);
+  });
 }
 
 function getValue(type) {
-  if (Array.isArray(type) && type.length === 2) {
+  if (Array.isArray(type)) {
     return getArrayValue(type);
   }
-  if (typeof type === "object" && type != null) {
+  if (typeof type === "object" && !Array.isArray(type) && type != null) {
     return createData(type);
   }
   try {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,23 @@ const Chance = require("chance");
 
 const chance = new Chance();
 
+function getArrayValue(definition) {
+  var type = definition[0];
+  var count = definition[1];
+  if (typeof type === "string" && typeof count === "number" && count > 0) {
+    return new Array(count).fill(null).map(function() {
+      return getValue(type);
+    });
+  } else {
+    return [];
+  }
+}
+
 function getValue(type) {
-  if (typeof type === "object" && !Array.isArray(type) && type != null) {
+  if (Array.isArray(type) && type.length === 2) {
+    return getArrayValue(type);
+  }
+  if (typeof type === "object" && type != null) {
     return createData(type);
   }
   try {


### PR DESCRIPTION
This patch adds support for arrays:

```js
$ fony -t '{"tags": ["word", 3]}'
{
  "tags": [
    "oklu",
    "odikabi",
    "coan"
  ]
}
```

I used the `["<chanceType>", <count>]` format, but if you have a better idea I take it.