### PR TITLE
Support shorthand object initializer syntax (fixes #9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/captainsafia/fony#readme",
   "dependencies": {
+    "babel-core": "^6.24.1",
     "chance": "^1.0.6",
     "commander": "^2.9.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const program = require('commander');
 
 const _version_ = require('../package.json').version;
 const createData = require('./utils');
+const transform = require('./transform');
 
 program
   .version(_version_);
@@ -16,7 +17,7 @@ program
 
 var template;
 try {
-  template = JSON.parse(program.template);
+  template = eval(transform(program.template));
 } catch (error) {
   return console.log(error);
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,26 @@
+// Generate AST from an es6 object initializer string
+// May want to support syntax like "word*3" to generate an array of 3 words
+// or other more complex syntaxes
+const babel = require("babel-core");
+
+// transforms ({ a: a }) or equivalently ({ a }) into
+// ({a: "a" }), note the value is stringified
+function transformPlugin(babel) {
+  const { types: t } = babel;
+
+  return {
+    visitor: {
+      Property({ node }) {
+        if (t.isIdentifier(node.value))
+          node.value = t.stringLiteral(node.value.name);
+      }
+    }
+  };
+}
+
+module.exports = code => {
+  return babel.transform(`(${code})`, {
+    plugins: [transformPlugin],
+    ast: false // don't need the ast (for now?)
+  }).code;
+};


### PR DESCRIPTION
This allows usage of ES6 Object Initializer Shorthand Syntax in the template. (JSON should continue working)

Examples:
fony -t '{ name, age, address }' will expand the template to
{ "name": "name", "age": "age", "address": "address" } and then generate fony data as per usual.

fony -t '{ name, age, location: address }' will expand the template to
{ "name": "name", "age": "age", "location": "address" }

Nested / array support continues to work so
`fony -t '{ names: { name1: name, name2: name }, location: address, phones: [  "phone", 3 ]  }'` will work just fine.

The template is transformed via a trivial babel plugin (src/transform.js).

Apart from less typing (always a good thing) it also makes working on Windows much easier, since  quotes are no longer mandatory for keynames or values! 

While this works, I realized we could support much more complex syntax and be more efficient if createData were to accept an AST instead of an object instance. We could for example allow syntax like this: (emmet flavoured?)

`{name, age, phone, known_locations: address*3 }` 

If there is interest I will work on a PR for emmet like syntax.